### PR TITLE
refactor: Adapt to php-mcp/server v1.1.0 changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": "^8.1",
         "laravel/framework": "^9.46 || ^10.34 || ^11.29 || ^12.0",
-        "php-mcp/server": "^1.0"
+        "php-mcp/server": "^1.1.0"
     },
     "require-dev": {
         "laravel/pint": "^1.13",
@@ -30,8 +30,7 @@
         "pestphp/pest-plugin-laravel": "^2.0",
         "mockery/mockery": "^1.6",
         "phpunit/phpunit": "^10.0 || ^11.0",
-        "react/http": "^1.11",
-        "php-mcp/react-transport": "^0.1.0"
+        "react/http": "^1.11"
     },
     "autoload": {
         "psr-4": {

--- a/samples/basic/composer.lock
+++ b/samples/basic/composer.lock
@@ -1151,16 +1151,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v12.10.2",
+            "version": "v12.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "0f123cc857bc177abe4d417448d4f7164f71802a"
+                "reference": "8f6cd73696068c28f30f5964556ec9d14e5d90d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/0f123cc857bc177abe4d417448d4f7164f71802a",
-                "reference": "0f123cc857bc177abe4d417448d4f7164f71802a",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/8f6cd73696068c28f30f5964556ec9d14e5d90d7",
+                "reference": "8f6cd73696068c28f30f5964556ec9d14e5d90d7",
                 "shasum": ""
             },
             "require": {
@@ -1362,7 +1362,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2025-04-24T14:11:20+00:00"
+            "time": "2025-05-01T16:13:12+00:00"
         },
         {
             "name": "laravel/prompts",
@@ -2799,12 +2799,12 @@
             "dist": {
                 "type": "path",
                 "url": "../..",
-                "reference": "fef9c24cf8939d05133babeb9c3249cacb964aa4"
+                "reference": "dbc9787595cef6a6160242b5cd2a7684b60bed1c"
             },
             "require": {
                 "laravel/framework": "^9.46 || ^10.34 || ^11.29 || ^12.0",
                 "php": "^8.1",
-                "php-mcp/server": "^1.0"
+                "php-mcp/server": "^1.1.0"
             },
             "require-dev": {
                 "laravel/pint": "^1.13",
@@ -2812,7 +2812,6 @@
                 "orchestra/testbench": "^8.0 || ^9.0",
                 "pestphp/pest": "^2.0",
                 "pestphp/pest-plugin-laravel": "^2.0",
-                "php-mcp/react-transport": "^0.1.0",
                 "phpunit/phpunit": "^10.0 || ^11.0",
                 "react/http": "^1.11"
             },
@@ -2871,16 +2870,16 @@
         },
         {
             "name": "php-mcp/server",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-mcp/server.git",
-                "reference": "83fa383dedfa769cc20cc2777cea2e6412d64a29"
+                "reference": "2ff0f7dde2178741fbcf7a64c767f5f3e272b392"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-mcp/server/zipball/83fa383dedfa769cc20cc2777cea2e6412d64a29",
-                "reference": "83fa383dedfa769cc20cc2777cea2e6412d64a29",
+                "url": "https://api.github.com/repos/php-mcp/server/zipball/2ff0f7dde2178741fbcf7a64c767f5f3e272b392",
+                "reference": "2ff0f7dde2178741fbcf7a64c767f5f3e272b392",
                 "shasum": ""
             },
             "require": {
@@ -2932,9 +2931,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-mcp/server/issues",
-                "source": "https://github.com/php-mcp/server/tree/1.0.0"
+                "source": "https://github.com/php-mcp/server/tree/1.1.0"
             },
-            "time": "2025-04-28T12:24:30+00:00"
+            "time": "2025-05-01T16:56:46+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -6371,16 +6370,16 @@
         },
         {
             "name": "vlucas/phpdotenv",
-            "version": "v5.6.1",
+            "version": "v5.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vlucas/phpdotenv.git",
-                "reference": "a59a13791077fe3d44f90e7133eb68e7d22eaff2"
+                "reference": "24ac4c74f91ee2c193fa1aaa5c249cb0822809af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/a59a13791077fe3d44f90e7133eb68e7d22eaff2",
-                "reference": "a59a13791077fe3d44f90e7133eb68e7d22eaff2",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/24ac4c74f91ee2c193fa1aaa5c249cb0822809af",
+                "reference": "24ac4c74f91ee2c193fa1aaa5c249cb0822809af",
                 "shasum": ""
             },
             "require": {
@@ -6439,7 +6438,7 @@
             ],
             "support": {
                 "issues": "https://github.com/vlucas/phpdotenv/issues",
-                "source": "https://github.com/vlucas/phpdotenv/tree/v5.6.1"
+                "source": "https://github.com/vlucas/phpdotenv/tree/v5.6.2"
             },
             "funding": [
                 {
@@ -6451,7 +6450,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-20T21:52:34+00:00"
+            "time": "2025-04-30T23:37:27+00:00"
         },
         {
             "name": "voku/portable-ascii",
@@ -6877,20 +6876,20 @@
         },
         {
             "name": "hamcrest/hamcrest-php",
-            "version": "v2.0.1",
+            "version": "v2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hamcrest/hamcrest-php.git",
-                "reference": "8c3d0a3f6af734494ad8f6fbbee0ba92422859f3"
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/8c3d0a3f6af734494ad8f6fbbee0ba92422859f3",
-                "reference": "8c3d0a3f6af734494ad8f6fbbee0ba92422859f3",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3|^7.0|^8.0"
+                "php": "^7.4|^8.0"
             },
             "replace": {
                 "cordoval/hamcrest-php": "*",
@@ -6898,8 +6897,8 @@
                 "kodova/hamcrest-php": "*"
             },
             "require-dev": {
-                "phpunit/php-file-iterator": "^1.4 || ^2.0",
-                "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0"
+                "phpunit/php-file-iterator": "^1.4 || ^2.0 || ^3.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0 || ^8.0 || ^9.0"
             },
             "type": "library",
             "extra": {
@@ -6922,9 +6921,9 @@
             ],
             "support": {
                 "issues": "https://github.com/hamcrest/hamcrest-php/issues",
-                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.0.1"
+                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.1.1"
             },
-            "time": "2020-07-09T08:09:16+00:00"
+            "time": "2025-04-30T06:54:44+00:00"
         },
         {
             "name": "jean85/pretty-package-versions",
@@ -7132,16 +7131,16 @@
         },
         {
             "name": "laravel/sail",
-            "version": "v1.41.1",
+            "version": "v1.42.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/sail.git",
-                "reference": "e5692510f1ef8e0f5096cde2b885d558f8d86592"
+                "reference": "2edaaf77f3c07a4099965bb3d7dfee16e801c0f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/sail/zipball/e5692510f1ef8e0f5096cde2b885d558f8d86592",
-                "reference": "e5692510f1ef8e0f5096cde2b885d558f8d86592",
+                "url": "https://api.github.com/repos/laravel/sail/zipball/2edaaf77f3c07a4099965bb3d7dfee16e801c0f6",
+                "reference": "2edaaf77f3c07a4099965bb3d7dfee16e801c0f6",
                 "shasum": ""
             },
             "require": {
@@ -7191,7 +7190,7 @@
                 "issues": "https://github.com/laravel/sail/issues",
                 "source": "https://github.com/laravel/sail"
             },
-            "time": "2025-04-22T13:39:39+00:00"
+            "time": "2025-04-29T14:26:46+00:00"
         },
         {
             "name": "mockery/mockery",
@@ -7278,16 +7277,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.13.0",
+            "version": "1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "024473a478be9df5fdaca2c793f2232fe788e414"
+                "reference": "1720ddd719e16cf0db4eb1c6eca108031636d46c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/024473a478be9df5fdaca2c793f2232fe788e414",
-                "reference": "024473a478be9df5fdaca2c793f2232fe788e414",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/1720ddd719e16cf0db4eb1c6eca108031636d46c",
+                "reference": "1720ddd719e16cf0db4eb1c6eca108031636d46c",
                 "shasum": ""
             },
             "require": {
@@ -7326,7 +7325,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.0"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.1"
             },
             "funding": [
                 {
@@ -7334,7 +7333,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-12T12:17:51+00:00"
+            "time": "2025-04-29T12:36:36+00:00"
         },
         {
             "name": "nunomaduro/collision",

--- a/src/Commands/ServeCommand.php
+++ b/src/Commands/ServeCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpMcp\Laravel\Server\Commands;
 
 use Illuminate\Console\Command;
+use PhpMcp\Server\Server;
 use PhpMcp\Server\Transports\StdioTransportHandler;
 use Psr\Log\LoggerInterface;
 
@@ -30,13 +31,16 @@ class ServeCommand extends Command
      * The StdioTransportHandler's start() method contains the blocking loop
      * for reading STDIN and writing to STDOUT.
      */
-    public function handle(StdioTransportHandler $handler, LoggerInterface $logger): int
+    public function handle(Server $server): int
     {
         if (! config('mcp.transports.stdio.enabled', false)) {
             $this->error('MCP STDIO transport is disabled. Cannot run mcp:serve.');
 
             return Command::FAILURE;
         }
+
+        $handler = new StdioTransportHandler($server);
+        $logger = app(LoggerInterface::class);
 
         $logger->info('Starting MCP server via mcp:serve (STDIO)...');
         $this->info('MCP server starting via STDIO. Listening for requests...');

--- a/src/Http/Controllers/McpController.php
+++ b/src/Http/Controllers/McpController.php
@@ -6,7 +6,7 @@ namespace PhpMcp\Laravel\Server\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
-use PhpMcp\Server\State\TransportState;
+use PhpMcp\Server\Server;
 use PhpMcp\Server\Transports\HttpTransportHandler;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Response;
@@ -14,16 +14,20 @@ use Throwable;
 
 class McpController
 {
+    private HttpTransportHandler $handler;
+
+    private LoggerInterface $logger;
+
     /**
      * MCP Controller Constructor
      *
      * Inject dependencies resolved by the service container.
      */
-    public function __construct(
-        private readonly HttpTransportHandler $handler,
-        private readonly TransportState $state,
-        private readonly LoggerInterface $logger
-    ) {}
+    public function __construct(Server $server)
+    {
+        $this->handler = new HttpTransportHandler($server);
+        $this->logger = app(LoggerInterface::class);
+    }
 
     /**
      * Handle client message (HTTP POST endpoint).


### PR DESCRIPTION
This PR updates the package to be compatible with the recent changes in `php-mcp/server v1.1.0`, primarily focusing on the dependency injection refactoring and transport handler updates.