### PR TITLE
[docs] Remove config call from app/bootstrap.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ For Laravel 11+:
 // bootstrap/app.php
 ->withMiddleware(function (Middleware $middleware) {
     $middleware->validateCsrfTokens(except: [
-        config('mcp.transports.http_integrated.route_prefix') . '/message',
+         'mcp/message', // Adjust if you changed the route prefix
     ]);
 })
 ```


### PR DESCRIPTION
I don't think it's safe to call this config() helper inside app/bootstrap.php. It gave me errors at least.

Also, why not add the integrated route to the API middleware by default, instead of web? I think you don't want sessions etc.