### PR TITLE
docs: transport should be explicitly set to stdio for the tool to start

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,8 @@ Configure your MCP client to execute this command directly. For example, in Curs
             "command": "php",
             "args": [
                 "/full/path/to/your/laravel/project/artisan",
-                "mcp:serve"
+                "mcp:serve",
+                "--transport=stdio"
             ]
         }
     }


### PR DESCRIPTION
When starting the tool is VSCode without providing a transport, it can't "Choose transport protocol for MCP server communication", so we need to explicitly define it.