### PR TITLE
Fix: Correct Client State Management in LaravelHttpTransport

### DIFF
--- a/src/Transports/LaravelHttpTransport.php
+++ b/src/Transports/LaravelHttpTransport.php
@@ -7,13 +7,11 @@ namespace PhpMcp\Laravel\Transports;
 use Evenement\EventEmitterTrait;
 use PhpMcp\Server\Contracts\LoggerAwareInterface;
 use PhpMcp\Server\Contracts\ServerTransportInterface;
-use PhpMcp\Server\Exception\TransportException;
 use PhpMcp\Server\State\ClientStateManager;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use React\Promise\PromiseInterface;
 
-use function React\Promise\reject;
 use function React\Promise\resolve;
 
 class LaravelHttpTransport implements ServerTransportInterface, LoggerAwareInterface
@@ -24,22 +22,10 @@ class LaravelHttpTransport implements ServerTransportInterface, LoggerAwareInter
 
     protected ClientStateManager $clientStateManager;
 
-    /** @var array<string, true> Tracks active client IDs managed by this transport */
-    private array $activeClients = [];
-
     public function __construct(ClientStateManager $clientStateManager)
     {
         $this->clientStateManager = $clientStateManager;
         $this->logger = new NullLogger;
-
-        $this->on('client_connected', function (string $clientId) {
-            $this->activeClients[$clientId] = true;
-            $this->clientStateManager->updateClientActivity($clientId);
-        });
-
-        $this->on('client_disconnected', function (string $clientId, string $reason) {
-            unset($this->activeClients[$clientId]);
-        });
 
         $this->on('message', function (string $message, string $clientId) {
             $this->clientStateManager->updateClientActivity($clientId);
@@ -68,12 +54,6 @@ class LaravelHttpTransport implements ServerTransportInterface, LoggerAwareInter
      */
     public function sendToClientAsync(string $clientId, string $rawFramedMessage): PromiseInterface
     {
-        if (! isset($this->activeClients[$clientId])) {
-            $this->logger->warning('Attempted to send message to inactive or unknown client.', ['clientId' => $clientId]);
-
-            return reject(new TransportException("Client '{$clientId}' is not actively managed by this transport."));
-        }
-
         $messagePayload = rtrim($rawFramedMessage, "\n");
 
         if (empty($messagePayload)) {
@@ -90,13 +70,7 @@ class LaravelHttpTransport implements ServerTransportInterface, LoggerAwareInter
      */
     public function close(): void
     {
-        $activeClientIds = array_keys($this->activeClients);
-
-        foreach ($activeClientIds as $clientId) {
-            $this->emit('client_disconnected', [$clientId, 'Transport globally closed']);
-            $this->emit('close', ['Transport closed.']);
-        }
-
+        $this->emit('close', ['Transport closed.']);
         $this->removeAllListeners();
     }
 }


### PR DESCRIPTION
This PR addresses a bug in `LaravelHttpTransport` that caused issues with tracking active clients, leading to "inactive or unknown client" errors when attempting to send messages.

**Problem:**

The `LaravelHttpTransport` previously maintained an internal, in-memory `$activeClients` array. In a standard Laravel request-response environment (without persistent workers like Octane), this transport instance is re-created for almost every HTTP interaction (initial SSE GET, message POSTs, SSE stream polls). This meant the in-memory `$activeClients` list was unreliable and often out of sync with the actual client state managed by `ClientStateManager` (which uses a persistent cache).

As a result, even if `ClientStateManager` knew a client was active (e.g., after `client_connected` was emitted in the SSE GET request), a subsequent `sendToClientAsync` call triggered by a server-side event might find the `$activeClients` array empty in the *new* transport instance handling that server-side logic, leading to failed message delivery.

**Solution:**

1.  Removed the internal `$activeClients` array from `LaravelHttpTransport`.
2.  Removed the `client_connected` and `client_disconnected` event listeners within `LaravelHttpTransport` that were managing this local array. Client connection and disconnection events are still emitted for the `Protocol` layer to handle with `ClientStateManager`.
3.  `LaravelHttpTransport::sendToClientAsync` now directly queues messages via `ClientStateManager` without checking the local `$activeClients` array.
4.  The existing `message` event listener in `LaravelHttpTransport` that calls `clientStateManager->updateClientActivity()` remains, as this is the correct way to signal activity to the persistent state manager.

Closes #13 