### PR TITLE
Update README.md to correct publishing command

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This package utilizes `php-mcp/server` v2.1.0+ which supports the `2024-11-05` v
 
 2.  **Publish Configuration:**
     ```bash
-    php artisan vendor:publish --provider="PhpMcp\Laravel\McpServiceProvider" --tag="mcp-config"
+    php artisan vendor:publish --provider="PhpMcp\Laravel\Server\McpServiceProvider" --tag="mcp-config"
     ```
 
 ## Configuration


### PR DESCRIPTION
Running

```php
php artisan vendor:publish --provider="PhpMcp\Laravel\McpServiceProvider" --tag="mcp-config"
```
does not work.


the service provider is actually:
```php
namespace PhpMcp\Laravel\Server;
class McpServiceProvider extends ServiceProvider
```

therefore, the publishing command should be:


```bash
php artisan vendor:publish --provider="PhpMcp\Laravel\Server\McpServiceProvider" --tag="mcp-config"
```