### PR TITLE
Fix STDIO transport stream errors on client disconnect

### DIFF
--- a/src/Commands/ServeCommand.php
+++ b/src/Commands/ServeCommand.php
@@ -89,8 +89,6 @@ class ServeCommand extends Command
             return Command::FAILURE;
         }
 
-        $this->info("MCP Server (STDIO) stopped.");
-
         return Command::SUCCESS;
     }
 


### PR DESCRIPTION
When MCP clients disconnect from STDIO transport, they close STDOUT/STDERR streams before the Laravel command completes. Attempting to output "MCP Server (STDIO) stopped." to closed streams causes fwrite() errors.

This PR removes the output message since STDIO transport should complete silently when clients disconnect - this is normal behavior, not an error condition.