### PR TITLE
feat: Add Closure Handler Support and Custom Input Schema for Tools

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": "^8.1",
         "laravel/framework": "^9.46 || ^10.34 || ^11.29 || ^12.0",
-        "php-mcp/server": "^3.1"
+        "php-mcp/server": "^3.2"
     },
     "require-dev": {
         "laravel/pint": "^1.13",

--- a/src/Blueprints/PromptBlueprint.php
+++ b/src/Blueprints/PromptBlueprint.php
@@ -8,8 +8,11 @@ class PromptBlueprint
 {
     public ?string $description = null;
 
+    /**
+     * @param string|array|callable $handler
+     */
     public function __construct(
-        public array|string $handler,
+        public mixed $handler,
         public ?string $name = null
     ) {}
 

--- a/src/Blueprints/ResourceBlueprint.php
+++ b/src/Blueprints/ResourceBlueprint.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMcp\Laravel\Blueprints;
 
+use Closure;
 use PhpMcp\Schema\Annotations;
 
 class ResourceBlueprint
@@ -18,9 +19,12 @@ class ResourceBlueprint
 
     public ?Annotations $annotations = null;
 
+    /**
+     * @param string|array|callable $handler
+     */
     public function __construct(
         public string $uri,
-        public array|string $handler,
+        public mixed $handler,
     ) {}
 
     public function name(string $name): static

--- a/src/Blueprints/ResourceTemplateBlueprint.php
+++ b/src/Blueprints/ResourceTemplateBlueprint.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMcp\Laravel\Blueprints;
 
+use Closure;
 use PhpMcp\Schema\Annotations;
 
 class ResourceTemplateBlueprint
@@ -16,9 +17,12 @@ class ResourceTemplateBlueprint
 
     public ?Annotations $annotations = null;
 
+    /**
+     * @param string|array|callable $handler
+     */
     public function __construct(
         public string $uriTemplate,
-        public array|string $handler,
+        public mixed $handler,
     ) {}
 
     public function name(string $name): static

--- a/src/Blueprints/ToolBlueprint.php
+++ b/src/Blueprints/ToolBlueprint.php
@@ -4,15 +4,20 @@ declare(strict_types=1);
 
 namespace PhpMcp\Laravel\Blueprints;
 
+use Closure;
 use PhpMcp\Schema\ToolAnnotations;
 
 class ToolBlueprint
 {
     public ?string $description = null;
     public ?ToolAnnotations $annotations = null;
+    public ?array $inputSchema = null;
 
+    /**
+     * @param string|array|callable $handler
+     */
     public function __construct(
-        public array|string $handler,
+        public mixed $handler,
         public ?string $name = null
     ) {}
 
@@ -33,6 +38,13 @@ class ToolBlueprint
     public function annotations(ToolAnnotations $annotations): static
     {
         $this->annotations = $annotations;
+
+        return $this;
+    }
+
+    public function inputSchema(array $inputSchema): static
+    {
+        $this->inputSchema = $inputSchema;
 
         return $this;
     }

--- a/src/Facades/Mcp.php
+++ b/src/Facades/Mcp.php
@@ -11,10 +11,10 @@ use PhpMcp\Laravel\Blueprints\ResourceTemplateBlueprint;
 use PhpMcp\Laravel\Blueprints\ToolBlueprint;
 
 /**
- * @method static ToolBlueprint tool(string|array $handlerOrName, array|string|null $handler = null)
- * @method static ResourceBlueprint resource(string $uri, array|string $handler)
- * @method static ResourceTemplateBlueprint resourceTemplate(string $uriTemplate, array|string $handler)
- * @method static PromptBlueprint prompt(string|array $handlerOrName, array|string|null $handler = null)
+ * @method static ToolBlueprint tool(string|callable|array $handlerOrName, callable|array|string|null $handler = null)
+ * @method static ResourceBlueprint resource(string $uri, callable|array|string $handler)
+ * @method static ResourceTemplateBlueprint resourceTemplate(string $uriTemplate, callable|array|string $handler)
+ * @method static PromptBlueprint prompt(string|callable|array $handlerOrName, callable|array|string|null $handler = null)
  *
  * @see \PhpMcp\Laravel\McpRegistrar
  */

--- a/src/McpRegistrar.php
+++ b/src/McpRegistrar.php
@@ -34,14 +34,14 @@ class McpRegistrar
      * Mcp::tool('tool_name', $handler)
      * Mcp::tool($handler) // Name will be inferred
      */
-    public function tool(string|array ...$args): ToolBlueprint
+    public function tool(string|callable|array ...$args): ToolBlueprint
     {
         $name = null;
         $handler = null;
 
-        if (count($args) === 1 && (is_array($args[0]) || (is_string($args[0]) && (class_exists($args[0]) || is_callable($args[0]))))) {
+        if (count($args) === 1 && (is_callable($args[0]) || is_array($args[0]) || (is_string($args[0]) && (class_exists($args[0]) || is_callable($args[0]))))) {
             $handler = $args[0];
-        } elseif (count($args) === 2 && is_string($args[0]) && (is_array($args[1]) || (is_string($args[1]) && (class_exists($args[1]) || is_callable($args[1]))))) {
+        } elseif (count($args) === 2 && is_string($args[0]) && (is_callable($args[1]) || is_array($args[1]) || (is_string($args[1]) && (class_exists($args[1]) || is_callable($args[1]))))) {
             $name = $args[0];
             $handler = $args[1];
         } else {
@@ -57,7 +57,7 @@ class McpRegistrar
     /**
      * Register a new resource.
      */
-    public function resource(string $uri, array|string $handler): ResourceBlueprint
+    public function resource(string $uri, callable|array|string $handler): ResourceBlueprint
     {
         $pendingResource = new ResourceBlueprint($uri, $handler);
         $this->pendingResources[] = $pendingResource;
@@ -68,7 +68,7 @@ class McpRegistrar
     /**
      * Register a new resource template.
      */
-    public function resourceTemplate(string $uriTemplate, array|string $handler): ResourceTemplateBlueprint
+    public function resourceTemplate(string $uriTemplate, callable|array|string $handler): ResourceTemplateBlueprint
     {
         $pendingResourceTemplate = new ResourceTemplateBlueprint($uriTemplate, $handler);
         $this->pendingResourceTemplates[] = $pendingResourceTemplate;
@@ -83,14 +83,14 @@ class McpRegistrar
      * Mcp::prompt('prompt_name', $handler)
      * Mcp::prompt($handler) // Name will be inferred
      */
-    public function prompt(string|array ...$args): PromptBlueprint
+    public function prompt(string|callable|array ...$args): PromptBlueprint
     {
         $name = null;
         $handler = null;
 
-        if (count($args) === 1 && (is_array($args[0]) || (is_string($args[0]) && (class_exists($args[0]) || is_callable($args[0]))))) {
+        if (count($args) === 1 && (is_callable($args[0]) || is_array($args[0]) || (is_string($args[0]) && (class_exists($args[0]) || is_callable($args[0]))))) {
             $handler = $args[0];
-        } elseif (count($args) === 2 && is_string($args[0]) && (is_array($args[1]) || (is_string($args[1]) && (class_exists($args[1]) || is_callable($args[1]))))) {
+        } elseif (count($args) === 2 && is_string($args[0]) && (is_callable($args[1]) || is_array($args[1]) || (is_string($args[1]) && (class_exists($args[1]) || is_callable($args[1]))))) {
             $name = $args[0];
             $handler = $args[1];
         } else {
@@ -106,7 +106,7 @@ class McpRegistrar
     public function applyBlueprints(ServerBuilder $builder): void
     {
         foreach ($this->pendingTools as $pendingTool) {
-            $builder->withTool($pendingTool->handler, $pendingTool->name, $pendingTool->description, $pendingTool->annotations);
+            $builder->withTool($pendingTool->handler, $pendingTool->name, $pendingTool->description, $pendingTool->annotations, $pendingTool->inputSchema);
         }
 
         foreach ($this->pendingResources as $pendingResource) {


### PR DESCRIPTION
### What's New

- **Closure Handler Support** - All MCP element types now accept closures/callables as handlers:

    ```php
    // Tools
    Mcp::tool(function(float $x, float $y): float {
        return $x * $y;
    })->name('multiply');
    
    // Resources  
    Mcp::resource('system://time', function(): string {
        return now()->toISOString();
    });
    
    // Resource Templates
    Mcp::resourceTemplate('file://{path}', function(string $path): string {
        return file_get_contents($path);
    });
    
    // Prompts
    Mcp::prompt(function(string $topic): array {
        return [['role' => 'user', 'content' => "Write about {$topic}"]];
    });
    ```

-  **Custom Input Schema for Tools** - Tools can now define custom JSON schemas for parameter validation:

    ```php
    Mcp::tool([CalculatorService::class, 'calculate'])
        ->inputSchema([
            'type' => 'object',
            'properties' => [
                'operation' => ['type' => 'string', 'enum' => ['add', 'subtract']],
                'numbers' => ['type' => 'array', 'items' => ['type' => 'number']]
            ],
            'required' => ['operation', 'numbers']
        ]);
    ```