### PR TITLE
Fix: correct argument order in response()->stream for legacy SSE mode

### DIFF
--- a/src/Transports/HttpServerTransport.php
+++ b/src/Transports/HttpServerTransport.php
@@ -169,7 +169,7 @@ class HttpServerTransport implements ServerTransportInterface
             }
 
             $this->emit('client_disconnected', [$sessionId, 'SSE stream closed']);
-        }, [
+        }, headers: [
             'Content-Type' => 'text/event-stream',
             'Cache-Control' => 'no-cache',
             'Connection' => 'keep-alive',


### PR DESCRIPTION
Fixes #30 

Fixed incorrect call to response()->stream(...) in HttpServerTransport::handleSseRequest