### PR TITLE
Fix ServeCommand output interfering with stdio JSON-RPC communication

### DIFF
--- a/src/Commands/ServeCommand.php
+++ b/src/Commands/ServeCommand.php
@@ -10,6 +10,7 @@ use PhpMcp\Server\Contracts\EventStoreInterface;
 use PhpMcp\Server\Transports\HttpServerTransport;
 use PhpMcp\Server\Transports\StdioServerTransport;
 use PhpMcp\Server\Transports\StreamableHttpServerTransport;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 
 use function Laravel\Prompts\select;
 
@@ -80,10 +81,14 @@ class ServeCommand extends Command
             return Command::FAILURE;
         }
 
-        $this->info('Starting MCP server');
-        $this->line("  - Transport: STDIO");
-        $this->line("  - Communication: STDIN/STDOUT");
-        $this->line("  - Mode: JSON-RPC over Standard I/O");
+        $output = $this->output->getOutput();
+
+        if ($output instanceof ConsoleOutputInterface) {
+            $output->getErrorOutput()->writeln("Starting MCP server");
+            $output->getErrorOutput()->writeln("  - Transport: STDIO");
+            $output->getErrorOutput()->writeln("  - Communication: STDIN/STDOUT");
+            $output->getErrorOutput()->writeln("  - Mode: JSON-RPC over Standard I/O");
+        }
 
         try {
             $transport = new StdioServerTransport;

--- a/tests/Feature/Commands/ServeCommandTest.php
+++ b/tests/Feature/Commands/ServeCommandTest.php
@@ -45,8 +45,8 @@ class ServeCommandTest extends TestCase
         );
 
         $this->artisan('mcp:serve --transport=stdio')
-            ->expectsOutputToContain('Starting MCP server')
-            ->expectsOutputToContain('Transport: STDIO')
+            ->doesntExpectOutputToContain('Starting MCP server')
+            ->doesntExpectOutputToContain('Transport: STDIO')
             ->assertSuccessful();
     }
 


### PR DESCRIPTION
This PR fixes an issue where the `ServeCommand` startup messages were being written to STDOUT, causing JSON parsing errors in MCP clients using stdio transport.

**Problem:**
Laravel's console output methods (`info()`, `line()`, etc.) sometimes write to STDOUT. In stdio MCP transport, STDOUT is reserved for JSON-RPC communication, so any extra output breaks the protocol.

**Solution:**
- Check if output supports error streams (`ConsoleOutputInterface`)
- Redirect startup messages to STDERR when available
- Fall back to no output if error stream unavailable

Fixes #33