### PR TITLE
Fix: Correct McpServiceProvider namespace in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ composer require php-mcp/laravel
 Publish the configuration file:
 
 ```bash
-php artisan vendor:publish --provider="PhpMcp\Laravel\McpServiceProvider" --tag="mcp-config"
+php artisan vendor:publish --provider="PhpMcp\Laravel\Server\McpServiceProvider" --tag="mcp-config"
 ```
 
 For database session storage, publish the migration:


### PR DESCRIPTION
This PR corrects the namespace for the McpServiceProvider in the README file's vendor:publish command. The previous namespace was incorrect, causing the command to fail.